### PR TITLE
feat: Allow exporting string values in text format

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ dependencies (`cue_library` rules, see below).
 | `name`          | Unique name for this rule (required)                                          |
 | `src`           | Cue compilation entry-point (required).                                       |
 | `deps`          | List of dependencies for the `src`. Each dependency is a `cue_library`        |
-| `output_format` | It should be one of :value:`json` or :value:`yaml`.                           |
+| `output_format` | It should be one of `json`, `text`, or `yaml`.                                |
 | `output_name`   | Output file name, including extension. Defaults to `<src_name>.json`          |
 
 ### cue_library

--- a/cue/cue.bzl
+++ b/cue/cue.bzl
@@ -264,9 +264,13 @@ def _cue_export_outputs(src, output_name, output_format):
     Returns:
       Outputs for the cue_export
     """
-
+    extension_by_format = {
+        "json": "json",
+        "text": "txt",
+        "yaml": "yaml",
+    }
     outputs = {
-        "export": output_name or _strip_extension(src.name) + "." + output_format,
+        "export": output_name or _strip_extension(src.name) + "." + extension_by_format[output_format],
     }
 
     return outputs
@@ -300,6 +304,7 @@ the input name, so use this attribute with caution.""",
         default = "json",
         values = [
             "json",
+            "text",
             "yaml",
         ],
     ),


### PR DESCRIPTION
Match the _cue export_ command's `--output` flag current set of supported output formats by adding the "text" format, accepted by _cue export_ only for exporting top-level string values.

Fixes #10.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tnarg/rules_cue/11)
<!-- Reviewable:end -->
