### PR TITLE
feat: Allow exporting a single selected expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ dependencies (`cue_library` rules, see below).
 | `name`          | Unique name for this rule (required)                                          |
 | `src`           | Cue compilation entry-point (required).                                       |
 | `deps`          | List of dependencies for the `src`. Each dependency is a `cue_library`        |
-| `output_format` | It should be one of :value:`json` or :value:`yaml`.                           |
+| `output_format` | It should be one of `json`, `text`, or `yaml`.                                |
 | `output_name`   | Output file name, including extension. Defaults to `<src_name>.json`          |
 
 ### cue_library

--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ dependencies (`cue_library` rules, see below).
 
 | Attribute       | Description                                                                   |
 |-----------------|-------------------------------------------------------------------------------|
-| `name`          | Unique name for this rule (required)                                          |
+| `name`          | Unique name for this rule (required).                                         |
 | `src`           | Cue compilation entry-point (required).                                       |
-| `deps`          | List of dependencies for the `src`. Each dependency is a `cue_library`        |
+| `deps`          | List of dependencies for the `src`. Each dependency is a `cue_library`.       |
+| `escape`        | Use HTML escaping.                                                            |
+| `expression`    | CUE expression selecting a single value to export.                            |
 | `output_format` | It should be one of `json`, `text`, or `yaml`.                                |
-| `output_name`   | Output file name, including extension. Defaults to `<src_name>.json`          |
+| `output_name`   | Output file name, including extension. Defaults to `<src_name>.json`.         |
 
 ### cue_library
 

--- a/cue/cue.bzl
+++ b/cue/cue.bzl
@@ -264,9 +264,13 @@ def _cue_export_outputs(src, output_name, output_format):
     Returns:
       Outputs for the cue_export
     """
-
+    extension_by_format = {
+        "json": "json",
+        "text": "txt",
+        "yaml": "yaml",
+    }
     outputs = {
-        "export": output_name or _strip_extension(src.name) + "." + output_format,
+        "export": output_name or _strip_extension(src.name) + "." + extension_by_format[output_format],
     }
 
     return outputs
@@ -300,6 +304,7 @@ the input name, so use this attribute with caution.""",
         default = "json",
         values = [
             "json",
+            "text",
             "yaml",
         ],
     ),

--- a/examples/hello_world/BUILD.bazel
+++ b/examples/hello_world/BUILD.bazel
@@ -7,6 +7,14 @@ cue_export(
 )
 
 cue_export(
+    name = "message",
+    src = "hello_world.cue",
+    expression = "message",
+    output_format = "text",
+    visibility = ["//visibility:public"],
+)
+
+cue_export(
     name = "de",
     src = "de.cue",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Expose the _cue export_ command's `--expression` flag, which exports only the value selected by the given CUE expression, as opposed to exporting all values in the given files or package.

NB: This is sitting on top of #11.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tnarg/rules_cue/12)
<!-- Reviewable:end -->
