### PR TITLE
Clean up unzipped artifacts after using them to generate the desired output

### DIFF
--- a/cue/cue.bzl
+++ b/cue/cue.bzl
@@ -38,8 +38,9 @@ CUE=$1; shift
 PKGZIP=$1; shift
 OUT=$1; shift
 
-unzip -q ${PKGZIP}
+unzip -qo ${PKGZIP}
 ${CUE} def -o ${OUT}
+zipinfo -1 ${PKGZIP} | xargs rm -rf
 """,
         inputs = [merged],
         outputs = [def_out],


### PR DESCRIPTION
The `CueDef` action runs the `cue def … <schema>` command to produce a single output: a `<target_name>~def.cue` file.  

To produce this output, the action first unzips a bunch of intermediate files to use as inputs to the `cue def` command.  

These inputs appear to sometimes cause problems, specifically `cue def` doesn't like it when there are `.cue` files in the top-level directory that belong to different packages.  This was happening on every first clean build in a Bazel `WORKSPACE` where I was adopting `rules_cue`.

I was able to solve this problem in my case by slightly altering the `CueDef` action to clean up the intermediate files after it produces the action's output.

Unfortunately, I was unable to create a minimally failing example in the `examples` folder of the `rules_cue` repository, and when I moved my consistently failing example into the `rules_cue` repository before the changes on this PR, my failing example started passing every time.

I would still humbly propose that this change be considered for merge into the canonical `rules_cue` repo: from a conceptual standpoint I'm not aware that these changes do anything that could be considered harmful, and these changes completely eliminate the problem I was having in my Bazel workspace.  I'd prefer to run against the canonical `rules_cue` instead of my fork.