### PR TITLE
Bazel 5 still refers to Mac M1 as aarch64

### DIFF
--- a/cue/BUILD.bazel
+++ b/cue/BUILD.bazel
@@ -30,7 +30,7 @@ config_setting(
     name = "darwin_arm64",
     constraint_values = [
         "@platforms//os:macos",
-        "@platforms//cpu:arm64",
+        "@platforms//cpu:aarch64",
     ],
 )
 

--- a/cue/cue.bzl
+++ b/cue/cue.bzl
@@ -38,7 +38,7 @@ CUE=$1; shift
 PKGZIP=$1; shift
 OUT=$1; shift
 
-unzip -q ${PKGZIP}
+unzip -qo ${PKGZIP}
 ${CUE} def -o ${OUT}
 """,
         inputs = [merged],
@@ -186,7 +186,7 @@ PKGZIP=$1; shift
 SRC=$1; shift
 OUT=$1; shift
 
-unzip -q ${PKGZIP}
+unzip -qo ${PKGZIP}
 ${CUE} export -o ${OUT} $@ ${SRC}
 """,
         inputs = [merged],
@@ -360,7 +360,7 @@ PKGZIP=$1; shift
 SCHEMA=$1; shift
 OUT=$1; shift
 
-unzip -q ${PKGZIP}
+unzip -qo ${PKGZIP}
 ${CUE} vet $@ "${SCHEMA}"
 touch $OUT
 """,

--- a/cue/deps.bzl
+++ b/cue/deps.bzl
@@ -30,13 +30,13 @@ _cue_runtimes = {
         {
             "os": "windows",
             "arch": "x86_64",
-            "url": "https://github.com/cue-lang/cue/releases/download/v0.4.0/cue_v0.4.2_windows_amd64.zip",
+            "url": "https://github.com/cue-lang/cue/releases/download/v0.4.2/cue_v0.4.2_windows_amd64.zip",
             "sha256": "95be4cd6b04b6c729f4f85a551280378d8939773c2eaecd79c70f907b5cae847",
         },
         {
             "os": "windows",
             "arch": "arm64",
-            "url": "https://github.com/cue-lang/cue/releases/download/v0.4.0/cue_v0.4.2_windows_arm64.zip",
+            "url": "https://github.com/cue-lang/cue/releases/download/v0.4.2/cue_v0.4.2_windows_arm64.zip",
             "sha256": "e03325656ca20d464307f68e3070d774af37e5777156ae983e166d7d7aed60df",
         },
     ],

--- a/examples/vet/BUILD
+++ b/examples/vet/BUILD
@@ -1,0 +1,12 @@
+load("@com_github_tnarg_rules_cue//cue:cue.bzl", "cue_vet_test")
+
+cue_vet_test(
+    name = "test_hello",
+    srcs = ["hello.yaml"],
+    schema = "schema.cue",
+    schema_expr = "#Def",
+    deps = [
+        "//examples/lang:cue_de_library",
+        "//examples/lang:cue_en_library",
+    ],
+)

--- a/examples/vet/hello.yaml
+++ b/examples/vet/hello.yaml
@@ -1,0 +1,6 @@
+message: "Hello, world!"
+random_number: 150
+---
+message: "Hallo, Welt!"
+random_number: 125
+extra: true

--- a/examples/vet/schema.cue
+++ b/examples/vet/schema.cue
@@ -1,0 +1,12 @@
+import (
+	"github.com/tnarg/rules_cue/examples/lang:en"
+	"github.com/tnarg/rules_cue/examples/lang:de"
+)
+
+#Def: {
+	message:       en.message | de.message
+	random_number: >12
+	extra?:        bool
+}
+
+close({})


### PR DESCRIPTION
For bazel 5 we need to be explicit about aarch64, once we move to bazel 5.1 and above we can pivot away from this and restore it back to arm64.

https://github.com/bazelbuild/bazel/issues/15175